### PR TITLE
Complete config names as well as commands

### DIFF
--- a/completions/chefvm.bash
+++ b/completions/chefvm.bash
@@ -3,7 +3,7 @@ _chefvm() {
   local word="${COMP_WORDS[COMP_CWORD]}"
 
   if [ "$COMP_CWORD" -eq 1 ]; then
-    COMPREPLY=( $(compgen -W "$(chefvm commands)" -- "$word") )
+    COMPREPLY=( $(compgen -W "$(chefvm commands) $(chefvm completions use)" -- "$word") )
   else
     local command="${COMP_WORDS[1]}"
     local completions="$(chefvm completions "$command")"

--- a/completions/chefvm.zsh
+++ b/completions/chefvm.zsh
@@ -10,7 +10,7 @@ _chefvm() {
   word="${words[2]}"
 
   if [ "${#words}" -eq 2 ]; then
-    completions="$(chefvm commands)"
+    completions="$(chefvm commands) $(chefvm completions use)"
   else
     completions="$(chefvm completions "${word}")"
   fi


### PR DESCRIPTION
Assuming you have a config named myconfig, the following:

```
$ chefvm my[TAB]
```

will complete to:

```
$ chefvm myconfig
```
