### PR TITLE
Fish 2.3.0 won't execute shell init

### DIFF
--- a/libexec/chefvm-init
+++ b/libexec/chefvm-init
@@ -88,8 +88,8 @@ function chefvm
   switch "\$command"
     case ${commands[*]}
       eval \`chefvm "sh-\$command" "\$argv"\`
-    case '*'
-      command chefvm "\$command" "\$argv"
+    case "*"
+      command chefvm "\$command" "\$argv";
   end
 end';
 eval 'chefvm setup';


### PR DESCRIPTION
Fish 2.3.0 altered the way switch statements work so now they must have a declared switch statement then the cases come after as documented here: https://fishshell.com/docs/current/tutorial.html#tut_conditionals

The line that produces the error in fish 2.3.0 is https://github.com/trobrock/chefvm/blob/4c009cd42e365a9146b6ef50e0b50d402e7c572c/libexec/chefvm-init#L38

Not expert enough on a fix just yet, but reporting it in case you have ideas on how to fix the issue. People who experience this issue also see: `No matches for wildcard ''` on shell startup now in the new fish.
